### PR TITLE
fix bug: ignore synthetic method

### DIFF
--- a/src/main/java/jodd/petite/resolver/MethodResolver.java
+++ b/src/main/java/jodd/petite/resolver/MethodResolver.java
@@ -59,6 +59,11 @@ public class MethodResolver {
 		for (final MethodDescriptor methodDescriptor : allMethods) {
 			final Method method = methodDescriptor.getMethod();
 
+			if (method.isSynthetic()) {
+				// ignore synthetic method
+				continue;
+			}
+
 			if (ClassUtil.isBeanPropertySetter(method)) {
 				// ignore setters
 				continue;


### PR DESCRIPTION
When i run the following code, it will occur error: MalformedParametersException: Invalid parameter name "".
```
public class IocTest {

    public static void main(String[] args) {
        PetiteContainer container = new PetiteContainer();
        container.addBean("aa", new MyClass());
    }

    public static class MyClass {

        @PetiteInitMethod
        public void test() {
            System.out.println("hh");
            new HashMap<>().forEach((k, v) -> System.out.println(k));

            new Thread(() -> System.out.print("aa"));
        }

        public void test22() {
            Map map = new HashMap();
            new Thread(() -> System.out.print(map));

            new Thread(IocTest::new);
        }
    }
}
```
note:
my jdk is 1.8
1. if this code run with eclipse 4.6.3, it 100% repetition; 
2. if i close eclipse compiler option 'Store information about method parameters', it run ok;
3. if this code run with eclipse 4.12, it also ok;
4. if this code compiler with javac, run no problem.
why run with eclipse 4.6.3 will failed, because 'ecj' compiler generate bytecode is following:
![image](https://user-images.githubusercontent.com/11604426/172838591-604568a8-09cb-4308-ad37-786ca07b1bc9.png)

And last, i also think synthetic method can ignore,  not only does this save space, it's also faster.
